### PR TITLE
Upgrade spring-boot-starter-parent 1.2.1.RELEASE to 1.2.8.RELEASE.

### DIFF
--- a/chat-tutorial/pom.xml
+++ b/chat-tutorial/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.2.1.RELEASE</version>
+        <version>1.2.8.RELEASE</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
#40 の対応で

spring-boot-starter-parentを1.2.1.RELEASEから1.2.8.RELEASEにアップグレードしました。

1.2.1.RELEASEでなければならない理由があれば本PRは破棄してください。
